### PR TITLE
add HODL support for bitcoin cash

### DIFF
--- a/js/coin.js
+++ b/js/coin.js
@@ -1045,11 +1045,8 @@
 			var address;
 			if (utxo_script['type'] == 'scriptpubkey') {
 				address = coinjs.scripthash2address(utxo_script['script'].slice(6, 46));
-			} else if (utxo_script['type'] == 'multisig') {
+			} else if (utxo_script['type'] == 'multisig' || utxo_script['type'] == 'hodl') {
 				address = coinjs.redeemscript2address(utxo_script['script']); // hash the redeemscript
-			} else if (utxo_script['type'] == 'hodl') {
-				alert('Bitcoin Cash hodl addresses not supported yet. Sorry.');
-				return false;
 			} else {
 				alert('Can not retreive input values for Bitcoin Cash signatures.');
 				return false;


### PR DESCRIPTION
Hello, 

I have added support for HODL addresses as I needed to determine a way to spend bitcoin cash that was tied to a HODL (OP_CHECKTIMELOCKVERIFY) based address.  

I have successfully signed and broadcasted a transaction from a HODL address using the code in this PR - this will allow people who have a HODL address to broadcast bitcoin cash transactions now as well. 

The successful HODL bitcoin cash transaction can be found here: 

https://blockchair.com/bitcoin-cash/transaction/243811230#o=0

Notice how there is a "Lock time" field present on the above blockchair transaction (screenshot attached as well) 

[http://imgur.com/a/mYmaQ](url)

Hopefully this is useful to others who are having trouble spending their timelocked bitcoin cash :) 

If you are looking at this post and found this useful and would like to thank me for my efforts, i'd gladly accept a donation at  **1J7AWtqXnGL6wLS5EUVikeZus4PDsAMG6s**

I'd also like to offer my heartfelt thanks to **dabura667** for the work he did on the coinbin fork getting it to properly work with the bitcoin network, he deserves most of the credit (I just made it function with a HODL address in addition to the multisig impl he added) 

Please let me know if there are any questions! 

